### PR TITLE
feat: API 공통 응답 포맷 추가

### DIFF
--- a/src/main/java/com/fatepet/global/response/ApiResponse.java
+++ b/src/main/java/com/fatepet/global/response/ApiResponse.java
@@ -1,0 +1,41 @@
+package com.fatepet.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private int status;
+
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    private ApiResponse(ResponseCode code, T data) {
+        this.status = code.getStatusCode();
+        this.message = code.getMessage();
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(ResponseCode code, T data) {
+        return new ApiResponse<>(code, data);
+    }
+
+    public static ApiResponse<Void> of(ResponseCode code) {
+        return new ApiResponse<>(code, null);
+    }
+
+    public static <T> ApiResponse<T> of(int status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+
+    public static ApiResponse<Void> of(int status, String message) {
+        return new ApiResponse<>(status, message, null);
+    }
+}

--- a/src/main/java/com/fatepet/global/response/ResponseCode.java
+++ b/src/main/java/com/fatepet/global/response/ResponseCode.java
@@ -1,0 +1,45 @@
+package com.fatepet.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ResponseCode {
+
+    // 200 OK
+    SUCCESS(HttpStatus.OK, "요청이 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
+    DUPLICATE_CHECK_PASSED(HttpStatus.OK, "중복 검사를 통과했습니다."),
+
+    // 400 BAD REQUEST
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    DUPLICATE(HttpStatus.BAD_REQUEST, "중복된 값입니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
+
+    // 401 UNAUTHORIZED
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요."),
+
+    // 403 FORBIDDEN
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+
+    // 404 NOT FOUND
+    NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ResponseCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/fatepet/petrest/consultrequest/ConsultRequest.java
+++ b/src/main/java/com/fatepet/petrest/consultrequest/ConsultRequest.java
@@ -11,7 +11,7 @@ public class ConsultRequest {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "funeral_business_id")
     private FuneralBusiness business;
 


### PR DESCRIPTION
## ✨ 공통 응답 포맷 클래스 추가

### 📌 작업 내용
- API의 응답 형식을 일관되게 관리하기 위해 공통 응답 클래스 `ApiResponse` 추가
- 응답 코드와 메시지를 Enum으로 관리하기 위한 `ResponseCode` 추가

### ✅ ApiResponse
- 제네릭 타입으로 다양한 응답 데이터를 포함할 수 있도록 설계
- 응답 필드: `status`, `message`, `data`
- `data`는 `null`일 경우 JSON 응답에서 제외되도록 `@JsonInclude` 사용
- 다양한 정적 팩토리 메서드를 통해 응답 생성 가능

### ✅ ResponseCode
- `HttpStatus` 기반의 응답 코드 및 메시지 관리
- 주요 응답 항목:
    - `SUCCESS`, `CREATED`, `DUPLICATE_CHECK_PASSED`
    - `INVALID_INPUT`, `DUPLICATE`, `INVALID_PASSWORD`, `SESSION_EXPIRED` 등

### 📎 사용 예시
```java
// ✅ Enum 기반 응답
return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, data));
return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(ResponseCode.CREATED));
return ResponseEntity.badRequest().body(ApiResponse.of(ResponseCode.INVALID_INPUT));

// ✅ 직접 상태 코드와 메시지를 지정
return ResponseEntity
       .status(HttpStatus.BAD_REQUEST)
       .body(ApiResponse.of(400, "서비스는 최소 1개 이상이어야 합니다."));

return ResponseEntity
       .status(HttpStatus.OK)
       .body(ApiResponse.of(200, "요청이 성공적으로 처리되었습니다.", data));